### PR TITLE
fix(init): correct 'plungins' typo to 'plugins' and fix prompt env var

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -40,9 +40,9 @@ p6df::modules::lua::langmgr::init() {
 ######################################################################
 p6df::modules::lua::home::symlinks() {
 
-  p6_dir_mk "$P6_SRC_DIR/cehoffman/luaenv/plungins"
-  p6_file_symlink "$P6_SRC_DIR/cehoffman/luaenv/plungins/lua-build" "$P6_DFZ_SRC_DIR/cehoffman/lua-build"
-  p6_file_symlink "$P6_SRC_DIR/cehoffman/luaenv/plungins/luaenv-luarocks" "$P6_DFZ_SRC_DIR/xpol/luaenv-luarocks"
+  p6_dir_mk "$P6_SRC_DIR/cehoffman/luaenv/plugins"
+  p6_file_symlink "$P6_SRC_DIR/cehoffman/luaenv/plugins/lua-build" "$P6_DFZ_SRC_DIR/cehoffman/lua-build"
+  p6_file_symlink "$P6_SRC_DIR/cehoffman/luaenv/plugins/luaenv-luarocks" "$P6_DFZ_SRC_DIR/xpol/luaenv-luarocks"
 
   p6_return_void
 }
@@ -104,5 +104,5 @@ p6df::modules::lua::prompt::lang() {
 ######################################################################
 p6df::modules::lua::prompt::env() {
 
-  p6_return_words 'lua' "$"
+  p6_return_words 'lua' '$LUAENV_ROOT'
 }

--- a/init.zsh
+++ b/init.zsh
@@ -104,5 +104,5 @@ p6df::modules::lua::prompt::lang() {
 ######################################################################
 p6df::modules::lua::prompt::env() {
 
-  p6_return_words 'lua' '$LUAENV_ROOT'
+  p6_return_words 'lua' "$LUAENV_ROOT"
 }


### PR DESCRIPTION
## What
Fix a typo in the luaenv plugins directory path (`plungins` → `plugins`) and correct the `prompt::env` function to return the actual `$LUAENV_ROOT` env var instead of a bare `"$"`.

## Why
The typo `plungins` caused symlinks to be created in the wrong directory, breaking luaenv plugin discovery. The prompt env function was returning a broken string instead of the real env var value.

## Test plan
- Reviewed diff confirms directory name corrected in all three calls (`p6_dir_mk` and both `p6_file_symlink`)
- `prompt::env` now returns `'$LUAENV_ROOT'` as intended

## Dependencies
None