### PR TITLE
fix(prompt): use single quotes for LUAENV_ROOT in prompt::env

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -104,5 +104,5 @@ p6df::modules::lua::prompt::lang() {
 ######################################################################
 p6df::modules::lua::prompt::env() {
 
-  p6_return_words 'lua' "$LUAENV_ROOT"
+  p6_return_words 'lua' '$LUAENV_ROOT'
 }


### PR DESCRIPTION
## What
Change `p6_return_words 'lua' "$LUAENV_ROOT"` to `p6_return_words 'lua' '$LUAENV_ROOT'` in `prompt::env`.

## Why
Using double quotes expands `$LUAENV_ROOT` at function definition time rather than call time; single quotes pass the literal variable name so `p6_return_words` can resolve it correctly at runtime.

## Test plan
- [ ] Reload shell; verify lua prompt env segment displays LUAENV_ROOT value correctly

## Dependencies
None